### PR TITLE
chore: #7 Update codebeat badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![codecov](https://codecov.io/gh/trustbloc/bloc-hub/branch/master/graph/badge.svg)](https://codecov.io/gh/trustbloc/bloc-hub)
 [![Go Report Card](https://goreportcard.com/badge/github.com/trustbloc/bloc-hub?style=flat-square)](https://goreportcard.com/report/github.com/trustbloc/bloc-hub)
-[![codebeat badge](https://codebeat.co/badges/b6dd2c0d-dec3-48f7-9a4f-af11bb138a1d)](https://codebeat.co/projects/github-com-trustbloc-bloc-hub-master)
+[![codebeat](https://codebeat.co/badges/e8c4452b-af9f-4a7f-b110-87c70c0df744)](https://codebeat.co/projects/github-com-trustbloc-bloc-hub-master)
 [![GolangCI](https://golangci.com/badges/github.com/trustbloc/bloc-hub.svg)](https://golangci.com/r/github.com/trustbloc/bloc-hub)
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://raw.githubusercontent.com/trustbloc/bloc-hub/master/LICENSE)


### PR DESCRIPTION
PR for #7:

Project was moved under the trustbloc org in codebeat,
hence the badge change.

Signed-off-by: George Aristy <george.aristy@securekey.com>